### PR TITLE
fix: style: fix incorrect margin/width

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,8 +11,8 @@ export default function Index({ tweets }: Props) {
 
   return (
     <div className="flex">
-      <div>
-        <div className="p-8 w-screen">
+      <div className="w-full">
+        <div className="p-8 w-full">
           <div
             className="flex w-full p-1 overflow-x-scroll items-center"
             style={{ height: '24rem' }}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,7 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+
+body {
+  margin: 0;
+}


### PR DESCRIPTION
名取さなさんお誕生日おめでとうございます💪（🎂🍆🎂💪）

ところで、以下について問題を認識しましたので修正を提案させていただきます。

# モバイル表示での表示崩れへの修正
bodyのデフォルトマージンが生きているため、表示崩れが起きていました。

`margin: 0`をbody要素に適用することで回避しています。

![ss1](https://user-images.githubusercontent.com/6778957/76039499-fc88b080-5f8f-11ea-90f4-3106ac0920d7.png)

# PC表示での表示崩れへの修正
ラッパー要素っぽいものに`width: 100vw`が設定されていたため、
スクロールバーのあるPC表示において、縦スクロールバーの領域が横幅に含まれてしまっていました。

tailwindから、`w-screen`の使用をやめ、代わりに`w-full`を利用するようにしました。

![ss2](https://user-images.githubusercontent.com/6778957/76039504-fe527400-5f8f-11ea-8eb7-9cbbbcb525ae.png)

---

TwitterAPIが必要っぽく、アプリのビルドができませんでしたので、サーバー立ち上げての表示確認取れてないです :cry: 